### PR TITLE
Added task for cleaning fasta assembly

### DIFF
--- a/tasks/task_clean_assembly.wdl
+++ b/tasks/task_clean_assembly.wdl
@@ -1,0 +1,51 @@
+version 1.0
+
+task clean_assembly {
+  input {
+    File assembly
+    String output_filename = "cleaned_assembly.fasta"
+    String docker = "us-docker.pkg.dev/general-theiagen/staphb/freyja:1.5.1-07_02_2024-01-27-2024-08-01"
+    Int memory = 8
+    Int disk_size = 50
+  }
+  
+  command <<<
+    set -e
+
+    echo "DEBUG: Cleaning assembly fastas..."
+    
+    python3 <<CODE
+    from Bio import SeqIO
+    import sys
+
+    def clean_header(header):
+        return header.split()[0]
+
+    def process_fasta(input_file, output_file):
+        with open(output_file, 'w') as outfile:
+            for record in SeqIO.parse(input_file, "fasta"):
+                record.id = clean_header(record.id)
+                record.description = ''
+                SeqIO.write(record, outfile, "fasta")
+
+    input_file = "~{assembly}"
+    output_file = "~{output_filename}"
+
+    process_fasta(input_file, output_file)
+    print(f"Cleaned assembly saved as {output_file}")
+    CODE
+  >>>
+  
+  output {
+    File cleaned_assembly = output_filename
+  }
+  
+  runtime {
+    docker: docker
+    memory: "~{memory} GB"
+    cpu: 1
+    disks: "local-disk ~{disk_size} SSD"
+    maxRetries: 2
+    preemptible: 1
+  }
+}

--- a/workflows/wf_allelecalling.wdl
+++ b/workflows/wf_allelecalling.wdl
@@ -1,6 +1,7 @@
 version 1.0
 
 import "../tasks/task_allelecalling.wdl" as allelecalling_task
+import "../tasks/task_clean_assembly.wdl" as clean_assembly_task
 import "wf_scheme_selection.wdl" as scheme_selection
 
 workflow allelecalling_wf {
@@ -16,9 +17,13 @@ workflow allelecalling_wf {
     input:
       scheme = scheme
   }
+  call clean_assembly_task.clean_assembly {
+    input:
+      assembly = assembly
+  }
   call allelecalling_task.allelecalling {
     input:
-      assembly = assembly,
+      assembly = clean_assembly.cleaned_assembly,
       samplename = samplename,
       blastdb_alleleinfo = scheme_selection.selected_blastdb_alleleinfo,
       blastdb_nhr = scheme_selection.selected_blastdb_nhr,


### PR DESCRIPTION
Added ability to clean fastas of assemblies coming from theiaprok and making sure it functions properly when submitted to allelecalling task. 

Updates:
All assemblies will be processed through task_clean_assemblies before being passed to the allelecalling step.